### PR TITLE
Add image support and buildrun 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,24 @@ This GitHub Action allows you to interact with IBM Cloud Code Engine. Deploy App
 
 ## Inputs
 
-| Name             | Required | Default Value    |Description                                                                                                                                                                                                                                                         |
-|------------------|----|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `api-key`        | ✅ | -                           | IAM API Key used to log into the IBM Cloud. Please store your IBM Cloud API key securely in your GitHub repository Secrets. |
-| `resource-group` | ❌ | Your Default Resource Group | An IBM Cloud Resource Group, a logical container for organizing and managing related cloud resources.|
-| `region`         | ✅ | -                           | The geographical area where your Code Engine project is located, like `eu-de` [codeengine-regions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-regions)|
-| `project`        | ✅ | -                           | The unique identifier (GUID) or the name that identifies your IBM Cloud Code Engine project. |
-| `component`      | ✅ | -                           | The type of component to deploy. allowed values `application`, `app`, `function`, `func`, `fn`, `job`, `build` |
-| `name`           | ✅ | -                           | The name of the App, Function, or Job. |
-| `image`          | ❌ | - | Name of the image used for this application or job |
-| `registry-secret`| ❌ | - | Name of the Code Engine registry secret used to authenticate against the Container registry |
-| `build-source`   | ❌ | .                           | Path to the directory containing the source code. See the Docs for additional information on how Code Engine builds [Apps, Jobs](https://cloud.ibm.com/docs/codeengine?topic=codeengine-build-config-local) and [Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-create-local) |
-| `build-strategy` | ❌ | buildpacks | Strategy used for building the image. allowed values `dockerfile`, `buildpacks` |
-| `build-size`     | ❌ | medium                      | The size of the build defines how CPU cores, memory, and disk space are assigned to the build. See the Docs for additional information for [Apps, and Jobs](https://cloud.ibm.com/docs/codeengine?topic=codeengine-plan-build#build-size) |
-| `cpu`            | ❌ | 1 / 0.5                     | CPU value set for your component Default for Apps and Jobs 1 vCPU, 0.5 vCPU for Functions. [Config for Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime), [Codeengine Memory CPU combo](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo) |
-| `memory`         | ❌ | 4G / 2G                     | Memory value set for your component Default for Apps and Jobs 4 GB, 2GB for Functions. [Config for Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime), [Codeengine Memory CPU combo](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo) |
-| `runtime`        | ❌ | -                           | The runtime used for the Function. Currently supported `nodejs-18` and `python-3.11` see [IBM Code Engine Function Runtimes](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime) for more information. |
+| Name              | Required | Default Value    |Description                                                                                                                                                                                                                                                         |
+|-------------------|----|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api-key`         | ✅ | -                           | IAM API Key used to log into the IBM Cloud. Please store your IBM Cloud API key securely in your GitHub repository Secrets. |
+| `resource-group`  | ❌ | Your Default Resource Group | An IBM Cloud Resource Group, a logical container for organizing and managing related cloud resources.|
+| `region`          | ✅ | -                           | The geographical area where your Code Engine project is located, like `eu-de` [codeengine-regions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-regions)|
+| `project`         | ✅ | -                           | The unique identifier (GUID) or the name that identifies your IBM Cloud Code Engine project. |
+| `component`       | ✅ | -                           | The type of component to deploy. allowed values `application`, `app`, `function`, `func`, `fn`, `job`, `build` |
+| `name`            | ✅ | -                           | The name of the App, Function, or Job. |
+| `image`           | ❌ | -                           | Name of the image used for this application or job |
+| `port`            | ❌ | -                           | Container port of the application |
+| `trusted-profiles`| ❌ | false                       | Enable trusted profiles for `application`, `function` or `job` |
+| `registry-secret` | ❌ | -                           | Name of the Code Engine registry secret used to authenticate against the Container registry |
+| `build-source`    | ❌ | .                           | Path to the directory containing the source code. See the Docs for additional information on how Code Engine builds [Apps, Jobs](https://cloud.ibm.com/docs/codeengine?topic=codeengine-build-config-local) and [Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-create-local) |
+| `build-strategy`  | ❌ | buildpacks | Strategy used for building the image. allowed values `dockerfile`, `buildpacks` |
+| `build-size`      | ❌ | medium                      | The size of the build defines how CPU cores, memory, and disk space are assigned to the build. See the Docs for additional information for [Apps, and Jobs](https://cloud.ibm.com/docs/codeengine?topic=codeengine-plan-build#build-size) |
+| `cpu`             | ❌ | 1 / 0.5                     | CPU value set for your component Default for Apps and Jobs 1 vCPU, 0.5 vCPU for Functions. [Config for Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime), [Codeengine Memory CPU combo](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo) |
+| `memory`          | ❌ | 4G / 2G                     | Memory value set for your component Default for Apps and Jobs 4 GB, 2GB for Functions. [Config for Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime), [Codeengine Memory CPU combo](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo) |
+| `runtime`         | ❌ | -                           | The runtime used for the Function. Currently supported `nodejs-18` and `python-3.11` see [IBM Code Engine Function Runtimes](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime) for more information. |
 
 ## Usage and Example
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,29 @@
 # Code Engine GitHub Action
 
-This GitHub Action allows you to interact with IBM Cloud Code Engine. Deploy Apps, Jobs, and Functions. It offers flexibility for different deployment types and provides various configuration options.
+This GitHub Action allows you to interact with IBM Cloud Code Engine. Deploy Apps, Jobs, and Functions or build Container images. It offers flexibility for different deployment types and provides various configuration options.
 
 ## Inputs
 
-| Name             | Required | Default Value               | Description                                                                                                                                                                                                                                                                                          |
-|------------------|----------|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `api-key`        | ✅        | -                           | IAM API Key used to log into the IBM Cloud. Please store your IBM Cloud API key securely in your GitHub repository Secrets.                                                                                                                                                                          |
-| `resource-group` | ❌        | Your Default Resource Group | An IBM Cloud Resource Group, a logical container for organizing and managing related cloud resources.                                                                                                                                                                                                |
-| `region`         | ✅        | -                           | The geographical area where your Code Engine project is located, like `eu-de` [codeengine-regions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-regions)                                                                                                                                   |
-| `project`        | ✅        | -                           | The unique identifier (GUID) or the name that identifies your IBM Cloud Code Engine project.                                                                                                                                                                                                         |
-| `component`      | ✅        | -                           | The type of component to deploy. allowed values `application`, `app`, `function`, `func`, `fn`, `job`                                                                                                                                                                                                |
-| `name`           | ✅        | -                           | The name of the App, Function, or Job.                                                                                                                                                                                                                                                               |
-| `build-source`   | ❌        | .                           | Path to the directory containing the source code. See the Docs for additional information on how Code Engine builds [Apps, Jobs](https://cloud.ibm.com/docs/codeengine?topic=codeengine-build-config-local) and [Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-create-local) |
-| `build-size`     | ❌        | medium                      | The size of the build defines how CPU cores, memory, and disk space are assigned to the build. See the Docs for additional information for [Apps, and Jobs](https://cloud.ibm.com/docs/codeengine?topic=codeengine-plan-build#build-size)                                                            |
-| `cpu`            | ❌        | 1 / 0.5                     | CPU value set for your component Default for Apps and Jobs 1 vCPU, 0.5 vCPU for Functions. [Config for Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime), [Codeengine Memory CPU combo](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo)           |
-| `memory`         | ❌        | 4G / 2G                     | Memory value set for your component Default for Apps and Jobs 4 GB, 2GB for Functions. [Config for Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime), [Codeengine Memory CPU combo](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo)               |
-| `runtime`        | ❌        | -                           | The runtime used for the Function. Currently supported `nodejs-18` and `python-3.11` see [IBM Code Engine Function Runtimes](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime) for more information.                                                                               |
+| Name             | Required | Default Value    |Description                                                                                                                                                                                                                                                         |
+|------------------|----|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `api-key`        | ✅ | -                           | IAM API Key used to log into the IBM Cloud. Please store your IBM Cloud API key securely in your GitHub repository Secrets. |
+| `resource-group` | ❌ | Your Default Resource Group | An IBM Cloud Resource Group, a logical container for organizing and managing related cloud resources.|
+| `region`         | ✅ | -                           | The geographical area where your Code Engine project is located, like `eu-de` [codeengine-regions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-regions)|
+| `project`        | ✅ | -                           | The unique identifier (GUID) or the name that identifies your IBM Cloud Code Engine project. |
+| `component`      | ✅ | -                           | The type of component to deploy. allowed values `application`, `app`, `function`, `func`, `fn`, `job`, `build` |
+| `name`           | ✅ | -                           | The name of the App, Function, or Job. |
+| `image`          | ❌ | - | Name of the image used for this application or job |
+| `registry-secret`| ❌ | - | Name of the Code Engine registry secret used to authenticate against the Container registry |
+| `build-source`   | ❌ | .                           | Path to the directory containing the source code. See the Docs for additional information on how Code Engine builds [Apps, Jobs](https://cloud.ibm.com/docs/codeengine?topic=codeengine-build-config-local) and [Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-create-local) |
+| `build-strategy` | ❌ | buildpacks | Strategy used for building the image. allowed values `dockerfile`, `buildpacks` |
+| `build-size`     | ❌ | medium                      | The size of the build defines how CPU cores, memory, and disk space are assigned to the build. See the Docs for additional information for [Apps, and Jobs](https://cloud.ibm.com/docs/codeengine?topic=codeengine-plan-build#build-size) |
+| `cpu`            | ❌ | 1 / 0.5                     | CPU value set for your component Default for Apps and Jobs 1 vCPU, 0.5 vCPU for Functions. [Config for Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime), [Codeengine Memory CPU combo](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo) |
+| `memory`         | ❌ | 4G / 2G                     | Memory value set for your component Default for Apps and Jobs 4 GB, 2GB for Functions. [Config for Functions](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime), [Codeengine Memory CPU combo](https://cloud.ibm.com/docs/codeengine?topic=codeengine-mem-cpu-combo) |
+| `runtime`        | ❌ | -                           | The runtime used for the Function. Currently supported `nodejs-18` and `python-3.11` see [IBM Code Engine Function Runtimes](https://cloud.ibm.com/docs/codeengine?topic=codeengine-fun-runtime) for more information. |
 
 ## Usage and Example
 
-To use this action, add it to your GitHub Actions workflow YAML file also make sure to add your IBM Cloud API Key as GitHub Action Repository Secret. There is a example for deploying an App, Job and Python/Node.js Function.
+To use this action, add it to your GitHub Actions workflow YAML file also make sure to add your IBM Cloud API Key as GitHub Action Repository Secret. There is a example for deploying an App, Job, Python/Node.js Function and a container build.
 
 *Deploy an App: `deploy-app.yml`*: Deploy your app to `Default` resource-group in `eu-de` to the project `MY-PROJECT` with its source code in the root of the repository the name of the app is`my-app`.
 
@@ -51,6 +54,73 @@ jobs:
         component: 'app'
         name: 'my-app'
         build-source: './'
+        cpu: 1
+        memory: 4G
+```
+
+*Deploy an App: `deploy-docker-app.yml`*: Deploy your app to `Default` resource-group in `eu-de` to the project `MY-PROJECT` with its source code in the root of the repository using the `dockerfile` `build-strategy` the name of the app is`my-docker-app`.
+
+```yaml
+name: Deploy App to Code Engine using Dockerfile build-strategy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  deploy-app:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Deploy App to Code Engine using Dockerfile build-strategy
+      uses: IBM/code-engine-github-action@v1
+      with:
+        api-key: ${{ secrets.IBM_IAM_API_KEY }}
+        resource-group: 'Default'
+        region: 'eu-de'
+        project: 'MY-PROJECT'
+        component: 'app'
+        build-strategy: dockerfile
+        name: 'my-docker-app'
+        build-source: './'
+        cpu: 1
+        memory: 4G
+```
+
+*Deploy an App using an existing Image: `deploy-app-image.yml`*: Deploy your app to `Default` resource-group in `eu-de` to the project `MY-PROJECT` using the existing `icr.io/codeengine/helloworld:latest` image the name of the app is`my-app`.
+
+```yaml
+name: Deploy Application to Code Engine using existing container image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  deploy-app:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Deploy Application to Code Engine using existing container image
+      uses: IBM/code-engine-github-action@v1
+      with:
+        api-key: ${{ secrets.IBM_IAM_API_KEY }}
+        resource-group: 'Default'
+        region: 'eu-de'
+        project: 'MY-PROJECT'
+        component: 'app'
+        name: 'my-img-app'
+        image: icr.io/codeengine/helloworld:latest
         cpu: 1
         memory: 4G
 ```
@@ -154,4 +224,37 @@ jobs:
         build-source: './'
         cpu: 1
         memory: 4G
+```
+
+*Building a Container Image: `build-container.yml`*: Build and push a Container Image `Default` resource-group in `eu-de` to the project `MY-PROJECT` with its source code in the root of the repository the name of the image is`private.de.icr.io/my-namespace/my-image:latest` the build name is `ce-build-image-{timestapm}` appended with the current timestamp using the auto generated regstry secret `ce-auto-icr-private-eu-de`.
+
+```yaml
+name: Build and push to ICR
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Build and push to ICR
+      uses: IBM/code-engine-github-action@v1
+      with:
+        api-key: ${{ secrets.IBM_IAM_API_KEY }}
+        resource-group: 'Default'
+        region: 'eu-de'
+        project: 'MY-PROJECT'
+        component: 'build'
+        name: 'ce-build-image'
+        image: private.de.icr.io/my-namespace/my-image:latest
+        registry-secret: ce-auto-icr-private-eu-de
+        build-source: './'
 ```

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ runs:
       env:
         CPU: ${{ inputs.cpu }} 
         MEMORY: ${{ inputs.memory }}
-        TRUSTED-PROFILES: ${{ inputs.trusted-profiles }}
+        TRUSTED_PROFILES: ${{ inputs.trusted-profiles }}
       run: |
         # set the CPU value
         if [[ "${CPU}" != "" ]] ; then
@@ -138,10 +138,10 @@ runs:
           echo "memory=" >> "$GITHUB_OUTPUT"
         fi
 
-        if [[ "${TRUSTED-PROFILES}" == "true" ]] ; then
-          echo "trusted-profiles=--trusted-profiles-enabled" >> "$GITHUB_OUTPUT"
+        if [[ "${TRUSTED_PROFILES}" == "true" ]] ; then
+          echo "TRUSTED_PROFILES=--TRUSTED_PROFILES-enabled" >> "$GITHUB_OUTPUT"
         else 
-          echo "trusted-profiles=" >> "$GITHUB_OUTPUT"
+          echo "TRUSTED_PROFILES=" >> "$GITHUB_OUTPUT"
         fi
 
     - name: configure-build-image
@@ -176,13 +176,13 @@ runs:
         BUILD_SOURCE: ${{ inputs.build-source }}
         CPU: ${{ steps.set-resources.outputs.cpu }} 
         MEMORY: ${{ steps.set-resources.outputs.memory }}
-        TRUSTED-PROFILES: ${{ steps.set-resources.outputs.trusted-profiles }}
+        TRUSTED_PROFILES: ${{ steps.set-resources.outputs.TRUSTED_PROFILES }}
       run: |
 
         if ibmcloud ce fn get --name ${NAME} ; then
-          ibmcloud ce fn update --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE} ${${TRUSTED-PROFILES}} ${CPU} ${MEMORY}
+          ibmcloud ce fn update --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE} ${${TRUSTED_PROFILES}} ${CPU} ${MEMORY}
         else
-          ibmcloud ce fn create --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE} ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
+          ibmcloud ce fn create --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE} ${TRUSTED_PROFILES} ${CPU} ${MEMORY}
         fi
 
     # Build Steps
@@ -225,7 +225,7 @@ runs:
         MEMORY: ${{ steps.set-resources.outputs.memory }}
         CONFBUILDIMG: ${{ steps.conf-build-img.outputs.build-img }}
         PORT: ${{ inputs.port }}
-        TRUSTED-PROFILES: ${{ steps.set-resources.outputs.trusted-profiles }}
+        TRUSTED_PROFILES: ${{ steps.set-resources.outputs.TRUSTED_PROFILES }}
       run: |
         # set the PORT value
         PORTFLAG=""
@@ -233,9 +233,9 @@ runs:
           PORTFLAG="--port ${PORT}"
         fi
         if ibmcloud ce application get --name ${NAME} ; then
-          ibmcloud ce application update --name ${NAME} ${CONFBUILDIMG} ${PORTFLAG} ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
+          ibmcloud ce application update --name ${NAME} ${CONFBUILDIMG} ${PORTFLAG} ${TRUSTED_PROFILES} ${CPU} ${MEMORY}
         else
-          ibmcloud ce application create --name ${NAME} ${CONFBUILDIMG} ${PORTFLAG} ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
+          ibmcloud ce application create --name ${NAME} ${CONFBUILDIMG} ${PORTFLAG} ${TRUSTED_PROFILES} ${CPU} ${MEMORY}
         fi
 
     # Job Steps
@@ -248,12 +248,12 @@ runs:
         CPU: ${{ steps.set-resources.outputs.cpu }} 
         MEMORY: ${{ steps.set-resources.outputs.memory }}
         CONFBUILDIMG: ${{ steps.conf-build-img.outputs.build-img }}
-        TRUSTED-PROFILES: ${{ steps.set-resources.outputs.trusted-profiles }}
+        TRUSTED_PROFILES: ${{ steps.set-resources.outputs.TRUSTED_PROFILES }}
       run: |
         if ibmcloud ce job get --name ${NAME} ; then
-          ibmcloud ce job update --name ${NAME} ${CONFBUILDIMG} --wait ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
+          ibmcloud ce job update --name ${NAME} ${CONFBUILDIMG} --wait ${TRUSTED_PROFILES} ${CPU} ${MEMORY}
         else
-          ibmcloud ce job create --name ${NAME} ${CONFBUILDIMG} --wait ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
+          ibmcloud ce job create --name ${NAME} ${CONFBUILDIMG} --wait ${TRUSTED_PROFILES} ${CPU} ${MEMORY}
         fi
 
     - name: Get component

--- a/action.yml
+++ b/action.yml
@@ -23,23 +23,36 @@ inputs:
     description: A Code Engine Project Is the grouping of your Apps, Functions and Jobs
     required: true
 
-# App, Function or Job Specific inputs
+# App, Function, Job or build Specific inputs
   component:
-    description: The type of component that should be deployed [App, Function, Job]
+    description: The type of component that should be deployed [App, Function, Job, Build]
     required: true
 
   name:
-    description: Name of the App, Function or Job
+    description: Name of the App, Function, Job or build
     required: true
 
   runtime:
     description: Runtime used for the Function only required for function
     required: false
 
+  image:
+    description:  Name of the image that is used for this application
+    required: false
+
+  registry-secret: 
+    description:  Name of the registry secret used to authenticate against the Container registry
+    required: false
+
   build-source:
     description: path to the directory containing the source code
     required: false
     default: .
+
+  build-strategy:
+    description: strategy used for building the image ['dockerfile', 'buildpacks']
+    required: false
+    default: buildpacks
 
   build-size:
     description: The size to use for the build, which determines the amount of resources used. Valid values include small, medium, large, xlarge, and xxlarge.
@@ -90,26 +103,50 @@ runs:
         if ibmcloud ce project select --name "${{ inputs.project }}" || ibmcloud ce project select --id ${{ inputs.project }} ; then
           echo "Project Selected"
         else
-          ibmcloud ce project create --name "${{ inputs.project }}"
+          ibmcloud ce project create --name "${{ inputs.project }}" --wait
         fi
 
     # set resources for target
     - name: Set resources
       id: set-resources
       shell: bash
+      env:
+        CPU: ${{ steps.set-resources.outputs.cpu }} 
+        MEMORY: ${{ steps.set-resources.outputs.memory }}
       run: |
         # set the CPU value
-        if [[ "${{ inputs.cpu }}" != "" ]] ; then
-          echo "cpu=--cpu ${{ inputs.cpu }}" >> "$GITHUB_OUTPUT"
+        if [[ "${CPU}" != "" ]] ; then
+          echo "cpu=--cpu ${CPU}" >> "$GITHUB_OUTPUT"
         else
           echo "cpu=" >> "$GITHUB_OUTPUT"
         fi
 
         # set the memory value
-        if [[ "${{ inputs.memory }}" != "" ]] ; then
-          echo "memory=--memory ${{ inputs.memory }}" >> "$GITHUB_OUTPUT"
+        if [[ "${MEMORY}" != "" ]] ; then
+          echo "memory=--memory ${MEMORY}" >> "$GITHUB_OUTPUT"
         else
           echo "memory=" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: configure-build-image
+      id: conf-build-img
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        REGION: ${{ inputs.region }}
+        REGISTRY_SECRET: ${{ inputs.registry-secret }}
+        BUILD_SOURCE: ${{ inputs.build-source }}
+        BUILD_STRATEGY: ${{ inputs.build-strategy }}
+        BUILD_SIZE: ${{ inputs.build-size }}
+      run: |
+        if [[ "${IMAGE}" != "" ]] ; then
+          if [[ "${REGISTRY_SECRET}" != "" ]]; then 
+            echo "build-img=--image ${IMAGE} --registry-secret ${REGISTRY_SECRET}" >> "$GITHUB_OUTPUT"
+          else 
+            echo "build-img=--image ${IMAGE}" >> "$GITHUB_OUTPUT"
+          fi
+        else 
+          echo "build-img=--build-source ${BUILD_SOURCE} --build-size ${BUILD_SIZE} --build-strategy ${BUILD_STRATEGY}" >> "$GITHUB_OUTPUT"
         fi
 
     # Functions Steps
@@ -117,12 +154,47 @@ runs:
       shell: bash
       id: fn-create
       if: ( inputs.component == 'function' || inputs.component == 'func' || inputs.component == 'fn' )
+      env:
+        NAME: ${{ inputs.name }}
+        RUNTIME: ${{ inputs.runtime }}
+        BUILD_SOURCE: ${{ inputs.build-source }}
+        CPU: ${{ steps.set-resources.outputs.cpu }} 
+        MEMORY: ${{ steps.set-resources.outputs.memory }}
       run: |
 
-        if ibmcloud ce fn get --name ${{ inputs.name }} ; then
-          ibmcloud ce fn update --name ${{ inputs.name }} --runtime ${{ inputs.runtime }} --build-source ${{ inputs.build-source }} ${{ steps.set-resources.outputs.cpu }} ${{ steps.set-resources.outputs.memory }}
+        if ibmcloud ce fn get --name ${NAME} ; then
+          ibmcloud ce fn update --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE}  ${CPU} ${MEMORY}
         else
-          ibmcloud ce fn create --name ${{ inputs.name }} --runtime ${{ inputs.runtime }} --build-source ${{ inputs.build-source }} ${{ steps.set-resources.outputs.cpu }} ${{ steps.set-resources.outputs.memory }}
+          ibmcloud ce fn create --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE}  ${CPU} ${MEMORY}
+        fi
+
+    # Build Steps
+    - name: Create or Update build
+      shell: bash
+      id: create-build
+      if: ( inputs.component == 'build')
+      env:
+        NAME: ${{ inputs.name }}
+        IMAGE: ${{ inputs.image }}
+        REGION: ${{ inputs.region }}
+        REGISTRY_SECRET: ${{ inputs.registry-secret }}
+        BUILD_SOURCE: ${{ inputs.build-source }}
+        BUILD_STRATEGY: ${{ inputs.build-strategy }}
+        BUILD_SIZE: ${{ inputs.build-size }}
+      run: |
+        if [[ "${IMAGE}" == "" ]] ; then 
+          echo "image needs to be set for build"
+          exit 1
+        fi
+        NAME=${NAME}-$(date +"%Y%m%d%H%M%S")
+        if ibmcloud ce buildrun get --name ${NAME} ; then
+          echo "buildrun already exists"
+        else
+          if [[ "${REGISTRY_SECRET}" == "" ]] ; then 
+            echo "using default secret for current region: ce-auto-icr-private-${REGION}"
+            REGISTRY_SECRET="ce-auto-icr-private-${REGION}"
+          fi
+          ibmcloud ce buildrun submit --name ${NAME} --source  ${BUILD_SOURCE} --strategy ${BUILD_STRATEGY} --image ${IMAGE} --registry-secret ${REGISTRY_SECRET}  --size ${BUILD_SIZE} --wait 
         fi
 
     # Application Steps
@@ -130,11 +202,16 @@ runs:
       shell: bash
       id: create-app
       if: ( inputs.component == 'application' || inputs.component == 'app' )
+      env:
+        NAME: ${{ inputs.name }}
+        CPU: ${{ steps.set-resources.outputs.cpu }} 
+        MEMORY: ${{ steps.set-resources.outputs.memory }}
+        CONFBUILDIMG: ${{ steps.conf-build-img.outputs.build-img }}
       run: |
-        if ibmcloud ce application get --name ${{ inputs.name }} ; then
-          ibmcloud ce application update --name ${{ inputs.name }} --build-source ${{ inputs.build-source }} --build-size ${{ inputs.build-size }} ${{ steps.set-resources.outputs.cpu }} ${{ steps.set-resources.outputs.memory }}
+        if ibmcloud ce application get --name ${NAME} ; then
+          ibmcloud ce application update --name ${NAME} ${CONFBUILDIMG} ${CPU} ${MEMORY}
         else
-          ibmcloud ce application create --name ${{ inputs.name }} --build-source ${{ inputs.build-source }} --build-size ${{ inputs.build-size }} ${{ steps.set-resources.outputs.cpu }} ${{ steps.set-resources.outputs.memory }}
+          ibmcloud ce application create --name ${NAME} ${CONFBUILDIMG} ${CPU} ${MEMORY}
         fi
 
     # Job Steps
@@ -142,26 +219,33 @@ runs:
       shell: bash
       id: create-job
       if: inputs.component == 'job'
+      env:
+        NAME: ${{ inputs.name }}
+        CPU: ${{ steps.set-resources.outputs.cpu }} 
+        MEMORY: ${{ steps.set-resources.outputs.memory }}
+        CONFBUILDIMG: ${{ steps.conf-build-img.outputs.build-img }}
       run: |
-        if ibmcloud ce job get --name ${{ inputs.name }} ; then
-          ibmcloud ce job update --name ${{ inputs.name }} --build-source ${{ inputs.build-source }} --build-size ${{ inputs.build-size }} --wait ${{ steps.set-resources.outputs.cpu }} ${{ steps.set-resources.outputs.memory }}
+        if ibmcloud ce job get --name ${NAME} ; then
+          ibmcloud ce job update --name ${NAME} ${CONFBUILDIMG} --wait ${CPU} ${MEMORY}
         else
-          ibmcloud ce job create --name ${{ inputs.name }} --build-source ${{ inputs.build-source }} --build-size ${{ inputs.build-size }} --wait ${{ steps.set-resources.outputs.cpu }} ${{ steps.set-resources.outputs.memory }}
+          ibmcloud ce job create --name ${NAME} ${CONFBUILDIMG} --wait ${CPU} ${MEMORY}
         fi
 
     - name: Get component
       shell: bash
       if: steps.fn-create.outcome == 'success' || steps.app-create.outcome == 'success' || steps.job-create.outcome == 'success'
+      env:
+        NAME: ${{ inputs.name }}
       run: |
         case ${{ inputs.component }} in
             function|func|fn)
-                ibmcloud ce fn get --name ${{ inputs.name }}
+                ibmcloud ce fn get --name  ${NAME}
                 ;;
             application|app)
-                ibmcloud ce app get --name ${{ inputs.name }}
+                ibmcloud ce app get --name  ${NAME}
                 ;;
             job)
-                ibmcloud ce job get --name ${{ inputs.name }}
+                ibmcloud ce job get --name  ${NAME}
                 ;;
             *)
                 echo "Wrong Code Engine component used!"

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,15 @@ inputs:
     description:  Name of the registry secret used to authenticate against the Container registry
     required: false
 
+  port:
+    description:  Port of the Application 
+    required: false
+  
+  trusted-profiles:
+    description: Enable trusted profiles
+    required: false
+    default: false
+
   build-source:
     description: path to the directory containing the source code
     required: false
@@ -111,8 +120,9 @@ runs:
       id: set-resources
       shell: bash
       env:
-        CPU: ${{ steps.set-resources.outputs.cpu }} 
-        MEMORY: ${{ steps.set-resources.outputs.memory }}
+        CPU: ${{ inputs.cpu }} 
+        MEMORY: ${{ inputs.memory }}
+        TRUSTED-PROFILES: ${{ inputs.trusted-profiles }}
       run: |
         # set the CPU value
         if [[ "${CPU}" != "" ]] ; then
@@ -126,6 +136,12 @@ runs:
           echo "memory=--memory ${MEMORY}" >> "$GITHUB_OUTPUT"
         else
           echo "memory=" >> "$GITHUB_OUTPUT"
+        fi
+
+        if [[ "${TRUSTED-PROFILES}" == "true" ]] ; then
+          echo "trusted-profiles=--trusted-profiles-enabled" >> "$GITHUB_OUTPUT"
+        else 
+          echo "trusted-profiles=" >> "$GITHUB_OUTPUT"
         fi
 
     - name: configure-build-image
@@ -160,12 +176,13 @@ runs:
         BUILD_SOURCE: ${{ inputs.build-source }}
         CPU: ${{ steps.set-resources.outputs.cpu }} 
         MEMORY: ${{ steps.set-resources.outputs.memory }}
+        TRUSTED-PROFILES: ${{ steps.set-resources.outputs.trusted-profiles }}
       run: |
 
         if ibmcloud ce fn get --name ${NAME} ; then
-          ibmcloud ce fn update --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE}  ${CPU} ${MEMORY}
+          ibmcloud ce fn update --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE} ${${TRUSTED-PROFILES}} ${CPU} ${MEMORY}
         else
-          ibmcloud ce fn create --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE}  ${CPU} ${MEMORY}
+          ibmcloud ce fn create --name ${NAME} --runtime ${RUNTIME} --build-source ${BUILD_SOURCE} ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
         fi
 
     # Build Steps
@@ -207,11 +224,18 @@ runs:
         CPU: ${{ steps.set-resources.outputs.cpu }} 
         MEMORY: ${{ steps.set-resources.outputs.memory }}
         CONFBUILDIMG: ${{ steps.conf-build-img.outputs.build-img }}
+        PORT: ${{ inputs.port }}
+        TRUSTED-PROFILES: ${{ steps.set-resources.outputs.trusted-profiles }}
       run: |
+        # set the PORT value
+        PORTFLAG=""
+        if [[ "${PORT}" != "" ]] ; then
+          PORTFLAG="--port ${PORT}"
+        fi
         if ibmcloud ce application get --name ${NAME} ; then
-          ibmcloud ce application update --name ${NAME} ${CONFBUILDIMG} ${CPU} ${MEMORY}
+          ibmcloud ce application update --name ${NAME} ${CONFBUILDIMG} ${PORTFLAG} ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
         else
-          ibmcloud ce application create --name ${NAME} ${CONFBUILDIMG} ${CPU} ${MEMORY}
+          ibmcloud ce application create --name ${NAME} ${CONFBUILDIMG} ${PORTFLAG} ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
         fi
 
     # Job Steps
@@ -224,11 +248,12 @@ runs:
         CPU: ${{ steps.set-resources.outputs.cpu }} 
         MEMORY: ${{ steps.set-resources.outputs.memory }}
         CONFBUILDIMG: ${{ steps.conf-build-img.outputs.build-img }}
+        TRUSTED-PROFILES: ${{ steps.set-resources.outputs.trusted-profiles }}
       run: |
         if ibmcloud ce job get --name ${NAME} ; then
-          ibmcloud ce job update --name ${NAME} ${CONFBUILDIMG} --wait ${CPU} ${MEMORY}
+          ibmcloud ce job update --name ${NAME} ${CONFBUILDIMG} --wait ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
         else
-          ibmcloud ce job create --name ${NAME} ${CONFBUILDIMG} --wait ${CPU} ${MEMORY}
+          ibmcloud ce job create --name ${NAME} ${CONFBUILDIMG} --wait ${TRUSTED-PROFILES} ${CPU} ${MEMORY}
         fi
 
     - name: Get component

--- a/action.yml
+++ b/action.yml
@@ -213,6 +213,9 @@ runs:
           fi
           ibmcloud ce buildrun submit --name ${NAME} --source  ${BUILD_SOURCE} --strategy ${BUILD_STRATEGY} --image ${IMAGE} --registry-secret ${REGISTRY_SECRET}  --size ${BUILD_SIZE} --wait 
         fi
+        BUILDRUNDATA=$(ibmcloud ce buildrun get --name ${NAME} --output json)
+        echo "Output image with digest: $(echo ${BUILDRUNDATA} | jq -r '.output_image' )@$(echo ${BUILDRUNDATA} | jq -r '.status_details.output_digest')" 
+
 
     # Application Steps
     - name: Create or Update Application


### PR DESCRIPTION
Add functionality to the GitHub Action to support:
- Container image build and push using Code Engine to ICR
- Use Public and private image for Apps and Jobs as an alternative to building from source
- make build-strategy configurable dockerfile or buildpacks as options

