### PR TITLE
Update IBM/actions-ibmcloud-cli action to v2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
   steps:
     # Default steps required
     - name: Install IBM Cloud CLI
-      uses: IBM/actions-ibmcloud-cli@v1
+      uses: IBM/actions-ibmcloud-cli@v2
       with:
         api_key: ${{ inputs.api-key }}
         region: ${{ inputs.region }}


### PR DESCRIPTION
Updated the CLI Action to v2 
- https://github.com/IBM/actions-ibmcloud-cli/releases/tag/v2.1.0

All manual test were successful fyi:  
- https://github.com/Luke-Roy-IBM/code-engine-test/actions/runs/23845434364
- https://github.com/Luke-Roy-IBM/code-engine-test/actions/runs/23845434341
- https://github.com/Luke-Roy-IBM/code-engine-test/actions/runs/23845434337
- https://github.com/Luke-Roy-IBM/code-engine-test/actions/runs/23845434335