### PR TITLE
Address findings from zizmor tool

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,11 +99,13 @@ runs:
     # If the project doesn`t exist the project is created with the provided Name
     - name: Select Code Engine Project
       shell: bash
+      env:
+        PROJECT: ${{ inputs.project }}
       run: |
-        if ibmcloud ce project select --name "${{ inputs.project }}" || ibmcloud ce project select --id ${{ inputs.project }} ; then
+        if ibmcloud ce project select --name "${PROJECT}" || ibmcloud ce project select --id ${PROJECT} ; then
           echo "Project Selected"
         else
-          ibmcloud ce project create --name "${{ inputs.project }}" --wait
+          ibmcloud ce project create --name "${PROJECT}" --wait
         fi
 
     # set resources for target
@@ -256,8 +258,9 @@ runs:
       if: steps.fn-create.outcome == 'success' || steps.app-create.outcome == 'success' || steps.job-create.outcome == 'success'
       env:
         NAME: ${{ inputs.name }}
+        COMPONENT: ${{ inputs.component }}
       run: |
-        case ${{ inputs.component }} in
+        case ${COMPONENT} in
             function|func|fn)
                 ibmcloud ce fn get --name  ${NAME}
                 ;;


### PR DESCRIPTION
The following changes address the findings from the zizmor static code scan
```bash
zizmor action.yml
🌈 zizmor v1.23.1
 INFO audit: zizmor: 🌈 completed action.yml
error[template-injection]: code injection via template expansion
   --> action.yml:103:51
    |
102 |       run: |
    |       --- this run block
103 |         if ibmcloud ce project select --name "${{ inputs.project }}" || ibmcloud ce project select --id ${{ inputs.project }} ; then
    |                                                   ^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
   --> action.yml:103:109
    |
102 |       run: |
    |       --- this run block
103 |         if ibmcloud ce project select --name "${{ inputs.project }}" || ibmcloud ce project select --id ${{ inputs.project }} ; then
    |                                                                                                             ^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
   --> action.yml:106:50
    |
102 |       run: |
    |       --- this run block
...
106 |           ibmcloud ce project create --name "${{ inputs.project }}" --wait
    |                                                  ^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

error[template-injection]: code injection via template expansion
   --> action.yml:260:18
    |
259 |       run: |
    |       --- this run block
260 |         case ${{ inputs.component }} in
    |                  ^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → High
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> action.yml:91:13
   |
91 |       uses: IBM/actions-ibmcloud-cli@v2
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

5 findings (4 fixable): 0 informational, 0 low, 0 medium, 5 high
```


The following finding will not be addressed as we want to recive updates from the ibmcloud cli action:
```bash
error[unpinned-uses]: unpinned action reference
  --> action.yml:91:13
   |
91 |       uses: IBM/actions-ibmcloud-cli@v2
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High
```